### PR TITLE
Add mnv3

### DIFF
--- a/MobileNetV3/README.md
+++ b/MobileNetV3/README.md
@@ -4,6 +4,8 @@
 
 MobileNetV3 is a light network aiming at object classfication. It can also been used as backbone of other computer vision networks, e.g., instance segmentation, depth estimation.
 
+MobileNetV3 contains two models, i.e., MobileNetV3-Large and MobileNetV3-Small. Both of the models are written in the python file and can be applied.
+
 ## Installation
 
 oneflow==0.3.5
@@ -11,13 +13,34 @@ oneflow==0.3.5
 ## Get started
 
 ### Prepare data
-Refer to the oneflow using cnn-classification to prepare the corresponding data set.
 
-### Train a model
+Refer to the oneflow using [cnn-classification](https://github.com/Oneflow-Inc/OneFlow-Benchmark/tree/master/Classification/cnns) to prepare the corresponding data set.
+
+### Train a model 
+
+Before training, it is necessary to add mobilenetv3_large and mobilenetv3_small model by changing part of_cnn_train_val.py:
+
+```
+model_dict = {
+    "resnet50": resnet_model.resnet50,
+    "vgg": vgg_model.vgg16bn,
+    "alexnet": alexnet_model.alexnet,
+    "inceptionv3": inception_model.inceptionv3,
+    "mobilenetv2": mobilenet_v2_model.Mobilenet,
+    "mobilenetv3_large": mobilenet_v3_model.Mobilenet_Large,
+    "mobilenetv3_small": mobilenet_v3_model.Mobilenet_Small,
+    "resnext50": resnext_model.resnext50,
+}
+```
+Also, import mobilenet_v3_model should be written in of_cnn_train_val.py.
+
+Then write the following command to train the model. Pay attention that either mobilenetv3_large or mobilenetv3_small should be defined.
 
 ```
 python3 of_cnn_train_val.py \
-  --model="mobilenetv3"
+  --model="mobilenetv3_large"
 ```
+
+It is also practical to change config.py directly to train the model with mobilenetv3_large or mobilenetv3_small.
 
 ### Compare

--- a/MobileNetV3/README.md
+++ b/MobileNetV3/README.md
@@ -1,0 +1,23 @@
+# MobilenetV3
+
+## Introduction
+
+MobileNetV3 is a light network aiming at object classfication. It can also been used as backbone of other computer vision networks, e.g., instance segmentation, depth estimation.
+
+## Installation
+
+oneflow==0.3.5
+
+## Get started
+
+### Prepare data
+Refer to the oneflow using cnn-classification to prepare the corresponding data set.
+
+### Train a model
+
+```
+python3 of_cnn_train_val.py \
+  --model="mobilenetv3"
+```
+
+### Compare

--- a/MobileNetV3/README.md
+++ b/MobileNetV3/README.md
@@ -4,7 +4,7 @@
 
 MobileNetV3 is a light network aiming at object classfication. It can also been used as backbone of other computer vision networks, e.g., instance segmentation, depth estimation.
 
-MobileNetV3 contains two models, i.e., MobileNetV3-Large and MobileNetV3-Small. Both of the models are written in the python file and can be applied.
+MobileNetV3 contains two models, i.e., ***MobileNetV3-Large*** and ***MobileNetV3-Small***. Both of the models are written in the python file and can be applied.
 
 ## Installation
 
@@ -18,7 +18,7 @@ Refer to the oneflow using [cnn-classification](https://github.com/Oneflow-Inc/O
 
 ### Train a model 
 
-Before training, it is necessary to add mobilenetv3_large and mobilenetv3_small model by changing part of_cnn_train_val.py:
+Before training, it is necessary to add *mobilenetv3_large* and *mobilenetv3_small* model by changing part *of_cnn_train_val.py*:
 
 ```
 model_dict = {
@@ -32,15 +32,20 @@ model_dict = {
     "resnext50": resnext_model.resnext50,
 }
 ```
-Also, import mobilenet_v3_model should be written in of_cnn_train_val.py.
+Also, import *mobilenet_v3_model* should be written in *of_cnn_train_val.py*.
 
-Then write the following command to train the model. Pay attention that either mobilenetv3_large or mobilenetv3_small should be defined.
+Then write the following command to train the model. Pay attention that either *mobilenetv3_large* or *mobilenetv3_small* should be defined.
 
 ```
 python3 of_cnn_train_val.py \
   --model="mobilenetv3_large"
 ```
 
-It is also practical to change config.py directly to train the model with mobilenetv3_large or mobilenetv3_small.
+It is also practical to change *config.py* directly to train the model with *mobilenetv3_large* or *mobilenetv3_small*.
 
 ### Compare
+
+|         | MobileNetV3-Large (%) | MobileNetV3-Small (%) |
+| :------: | :----------------:  | :------------------: |
+|  Paper  |         75.2        |         67.5        |
+| OneFlow |         70.5       |       (testing) 

--- a/MobileNetV3/README.md
+++ b/MobileNetV3/README.md
@@ -48,8 +48,8 @@ It is also practical to change *config.py* directly to train the model with *mob
 |         | MobileNetV3-Large (%) | MobileNetV3-Small (%) |
 | :------: | :----------------:  | :------------------: |
 |  Paper  |         75.2        |         67.5        |
-| OneFlow |         70.5       |       53.2
+| OneFlow |         70.5       |       69.3
 
  
-As is shown in the table, both MobileNetV3-Large model and MobileNetV3-Small model has lower accuracy than that of paper.
-Modcl checking, especially parameter improvements have to be conducted to achieve higher accuracy.
+As is shown in the table, our MobileNetV3-Small model has a better performance in accuracy compared with the paper,
+while MobileNetV3-Large model still need tuning to improve accuracy.

--- a/MobileNetV3/README.md
+++ b/MobileNetV3/README.md
@@ -48,4 +48,8 @@ It is also practical to change *config.py* directly to train the model with *mob
 |         | MobileNetV3-Large (%) | MobileNetV3-Small (%) |
 | :------: | :----------------:  | :------------------: |
 |  Paper  |         75.2        |         67.5        |
-| OneFlow |         70.5       |       (testing) 
+| OneFlow |         70.5       |       53.2
+
+ 
+As is shown in the table, both MobileNetV3-Large model and MobileNetV3-Small model has lower accuracy than that of paper.
+Modcl checking, especially parameter improvements have to be conducted to achieve higher accuracy.

--- a/MobileNetV3/mobilenet_v3_model.py
+++ b/MobileNetV3/mobilenet_v3_model.py
@@ -18,14 +18,10 @@ def _get_initializer(model_name):
     elif model_name == "dense_weight":
         return flow.random_normal_initializer(0, 0.01)
 
-def _conv2d(name, x, filters, kernel_size, strides, num_group, padding="SAME", data_format="NCHW"):  # tested
+def _conv2d(name, x, filters, kernel_size, strides, num_group, padding="SAME", data_format="NCHW"):
     assert data_format=="NCHW", "Mobilenet does not support channel_last mode."
     weight_initializer = _get_initializer("weight")
-<<<<<<< HEAD
     weight_regularizer=_get_regularizer("beta")
-=======
-    weight_regularizer=_get_regularizer("beta")  # review it
->>>>>>> c7ec222a7d728705e396bc7441bc3254f295d2c4
 
     shape = (filters, x.shape[1] // num_group, kernel_size, kernel_size)
     weight = flow.get_variable(
@@ -35,15 +31,11 @@ def _conv2d(name, x, filters, kernel_size, strides, num_group, padding="SAME", d
         initializer=weight_initializer,
         regularizer=weight_regularizer,
         model_name="--weight",
-<<<<<<< HEAD
         trainable=True,
-=======
-        trainable=True,  # review it
->>>>>>> c7ec222a7d728705e396bc7441bc3254f295d2c4
     )
     return flow.nn.conv2d(x, weight, strides, padding, data_format, name=name, groups=num_group)
 
-def _batch_norms(name, x, axis, momentum, epsilon, center=True, scale=True, trainable=True):  # tested
+def _batch_norms(name, x, axis, momentum, epsilon, center=True, scale=True, trainable=True):
     return flow.layers.batch_normalization(
         name=name,
         inputs=x,
@@ -67,14 +59,10 @@ def hsigmoid(x):
     out = flow.nn.relu6(x + 3) / 6
     return out
 
-<<<<<<< HEAD
-=======
-# valid numbers outputted
->>>>>>> c7ec222a7d728705e396bc7441bc3254f295d2c4
 def SeModule(name, x, channel, reduction=4):
     N, C, H, W = x.shape
 
-    y = flow.nn.avg_pool2d(x, ksize=[H, W], strides=None, padding="SAME")  # check here
+    y = flow.nn.avg_pool2d(x, ksize=[H, W], strides=None, padding="SAME")
     y = flow.flatten(y, start_dim=1, end_dim=-1)
     y = flow.layers.dense(
         y, 
@@ -104,7 +92,6 @@ def SeModule(name, x, channel, reduction=4):
     out = x * y_expand
     return out
 
-# valid number outputted
 def small_unit(name, x, kernel_size=1, num_filter=1, strides=1, padding="SAME", num_group=1, data_format="NCHW", act=None):
     conv = _conv2d(name=name+"-small_unit", x=x, filters=num_filter, kernel_size=kernel_size, strides=strides,
             num_group=num_group, padding=padding, data_format=data_format)
@@ -116,15 +103,11 @@ def small_unit(name, x, kernel_size=1, num_filter=1, strides=1, padding="SAME", 
     else:
         return bn
 
-<<<<<<< HEAD
-=======
-# valid numbers outputted. But may be strange.
->>>>>>> c7ec222a7d728705e396bc7441bc3254f295d2c4
 def mnv3_unit(name, x, kernel_size, expansion, num_filter, shortcut, strides, act, sechannel, data_format="NCHW"):
     # num_exp_filter = int(round(num_in_filter * expansion_factor))
     y = small_unit(name+"-mnv3_unit1", x, kernel_size=1, num_filter=expansion, strides=1, padding="VALID", num_group=1, act=act)
     y = small_unit(name+"-mnv3_unit2", y, kernel_size=kernel_size, num_filter=expansion, strides=strides, 
-        padding=([0, 0, kernel_size//2, kernel_size//2]), num_group=expansion, act=act)  # check the padding
+        padding=([0, 0, kernel_size//2, kernel_size//2]), num_group=expansion, act=act)
     out = small_unit(name+"-mnv3_unit3", y, kernel_size=1, num_filter=num_filter, strides=1, padding="VALID", num_group=1, act=None)
     if sechannel != None:
         out = SeModule(name+"-semodule", out, sechannel)
@@ -152,13 +135,8 @@ def MobileNetV3_Large(x, data_format="NCHW", num_class=1000):
     layerneck = mnv3_unit("large-neck15", layerneck, 3, 960, 160, False, 1, "_hswish", 160)
     layer2 = small_unit("large-layer2", layerneck, num_filter=960, act="_hswish", padding="VALID")  # number > 1 exists
 
-    layer_avg = flow.nn.avg_pool2d(layer2, ksize=[layer2.shape[2], layer2.shape[3]], strides=None, padding="VALID")  # review it 
-<<<<<<< HEAD
+    layer_avg = flow.nn.avg_pool2d(layer2, ksize=[layer2.shape[2], layer2.shape[3]], strides=None, padding="VALID")
     layer_view = flow.reshape(layer_avg, (layer_avg.shape[0], -1)) 
-=======
-    layer_view = flow.reshape(layer_avg, (layer_avg.shape[0], -1))  # review it
-
->>>>>>> c7ec222a7d728705e396bc7441bc3254f295d2c4
     dense3 = flow.layers.dense(
         layer_view, 
         units=1280, 
@@ -181,7 +159,6 @@ def MobileNetV3_Large(x, data_format="NCHW", num_class=1000):
         bias_regularizer=_get_regularizer("bias"),
         name="dense4-large",
     )
-
     return dense4
 
 def MobileNetV3_Small(x, data_format="NCHW", num_class=1000):
@@ -199,9 +176,8 @@ def MobileNetV3_Small(x, data_format="NCHW", num_class=1000):
     layerneck = mnv3_unit("small-neck10", layerneck, 5, 576, 96, True, 1, "_hswish", 96)
     layerneck = mnv3_unit("small-neck11", layerneck, 5, 576, 96, True, 1, "_hswish", 96)
 
-<<<<<<< HEAD
     layer2 = small_unit("small-layer2", layerneck, num_filter=576, act="_hswish", padding="VALID")
-    layer_avg = flow.nn.avg_pool2d(layer2, ksize=[layer2.shape[2], layer2.shape[3]], strides=None, padding="VALID")  # review it
+    layer_avg = flow.nn.avg_pool2d(layer2, ksize=[layer2.shape[2], layer2.shape[3]], strides=None, padding="VALID")
     layer_view = flow.reshape(layer_avg, (layer_avg.shape[0], -1))
     dense3 = flow.layers.dense(
         layer_view, 
@@ -213,12 +189,6 @@ def MobileNetV3_Small(x, data_format="NCHW", num_class=1000):
         bias_regularizer=_get_regularizer("bias"),
         name="dense3-large",
         )
-=======
-    layer2 = small_unit("small-layer2", layerneck, num_filter=576, act="_hswish")
-    layer_avg = flow.nn.avg_pool2d(layer2, ksize=[layer2.shape[2], layer2.shape[3]], strides=None, padding="VALID")  # review it
-    layer_view = flow.reshape(layer_avg, (layer_avg.shape[0], -1))  # review it
-    dense3 = flow.layers.dense(layer_view, 1280)
->>>>>>> c7ec222a7d728705e396bc7441bc3254f295d2c4
     bn3 = _batch_norms("bn3-large", dense3, axis=1, momentum=0.9, epsilon=1e-5)
     hs3 = hswish(bn3)
     dense4 = flow.layers.dense(
@@ -231,8 +201,6 @@ def MobileNetV3_Small(x, data_format="NCHW", num_class=1000):
         bias_regularizer=_get_regularizer("bias"),
         name="dense4-large",
         )
-    print(dense4.shape)
-
     return dense4
 
 def Mobilenet_Large(input_data, args, trainable=True, training=True, num_classes=1000, prefix = ""):

--- a/MobileNetV3/mobilenet_v3_model.py
+++ b/MobileNetV3/mobilenet_v3_model.py
@@ -1,0 +1,220 @@
+import oneflow as flow
+import oneflow.typing as tp
+import numpy as np
+
+def _get_regularizer(model_name):
+    #all decay
+    return flow.regularizers.l2(0.00004)
+
+def _get_initializer(model_name):
+    if model_name == "weight":
+        return flow.variance_scaling_initializer(2.0, mode="fan_in", distribution="random_normal", data_format="NCHW")
+    elif model_name == "bias":
+        return flow.zeros_initializer()
+    elif model_name == "gamma":
+        return flow.ones_initializer()
+    elif model_name == "beta":
+        return flow.zeros_initializer()
+    elif model_name == "dense_weight":
+        return flow.random_normal_initializer(0, 0.01)
+
+def _conv2d(name, x, filters, kernel_size, strides, num_group, padding="SAME", data_format="NCHW"):  # tested
+    assert data_format=="NCHW", "Mobilenet does not support channel_last mode."
+    weight_initializer = _get_initializer("weight")
+    weight_regularizer=_get_regularizer("beta")
+
+    shape = (filters, x.shape[1] // num_group, kernel_size, kernel_size)
+    weight = flow.get_variable(
+        name + "-weight",
+        shape=shape,
+        dtype=x.dtype,
+        initializer=weight_initializer,
+        regularizer=weight_regularizer,
+        model_name="--weight",
+        trainable=True,
+    )
+    return flow.nn.conv2d(x, weight, strides, padding, data_format, name=name, groups=num_group)
+
+def _batch_norms(name, x, axis, momentum, epsilon, center=True, scale=True, trainable=True):  # tested
+    return flow.layers.batch_normalization(
+        name=name,
+        inputs=x,
+        axis=axis,
+        momentum=momentum,
+        epsilon=epsilon,
+        center=center,
+        scale=scale,
+        beta_initializer = _get_initializer("beta"),
+        gamma_initializer = _get_initializer("gamma"),
+        beta_regularizer = _get_regularizer("beta"),
+        gamma_regularizer = _get_regularizer("gamma"),
+        trainable=trainable
+    )
+
+def hswish(x):
+    out =  x * flow.nn.relu6(x + 3) / 6
+    return out
+
+def hsigmoid(x):
+    out = flow.nn.relu6(x + 3) / 6
+    return out
+
+def SeModule(name, x, channel, reduction=4):
+    N, C, H, W = x.shape
+
+    y = flow.nn.avg_pool2d(x, ksize=[H, W], strides=None, padding="SAME")  # check here
+    y = flow.flatten(y, start_dim=1, end_dim=-1)
+    y = flow.layers.dense(
+        y, 
+        units=channel // reduction, 
+        use_bias=False,
+        kernel_initializer=_get_initializer("dense_weight"),
+        bias_initializer=_get_initializer("bias"),
+        kernel_regularizer=_get_regularizer("dense_weight"),
+        bias_regularizer=_get_regularizer("bias"),
+        name=name+"dense1a",
+        )
+    y = flow.math.relu(y)
+    y = flow.layers.dense(
+        y, 
+        units=channel, 
+        use_bias=False,
+        kernel_initializer=_get_initializer("dense_weight"),
+        bias_initializer=_get_initializer("bias"),
+        kernel_regularizer=_get_regularizer("dense_weight"),
+        bias_regularizer=_get_regularizer("bias"),
+        name=name+"dense2",
+        )
+    y = hsigmoid(y)
+    y = flow.expand_dims(input=y, axis=2)
+    y = flow.expand_dims(input=y, axis=3)
+    y_expand = flow.broadcast_like(y, x, broadcast_axes=(2, 3))
+    out = x * y_expand
+    return out
+
+# valid number outputted
+def small_unit(name, x, kernel_size=1, num_filter=1, strides=1, padding="SAME", num_group=1, data_format="NCHW", act=None):
+    conv = _conv2d(name=name+"-small_unit", x=x, filters=num_filter, kernel_size=kernel_size, strides=strides,
+            num_group=num_group, padding=padding, data_format=data_format)
+    bn = _batch_norms(name+"-small_unit_bn", conv, axis=1, momentum=0.9, epsilon=1e-5)
+    if act == "_relu":
+        return flow.math.relu(bn)
+    elif act == "_hswish":
+        return hswish(bn)
+    else:
+        return bn
+
+def mnv3_unit(name, x, kernel_size, expansion, num_filter, shortcut, strides, act, sechannel, data_format="NCHW"):
+    # num_exp_filter = int(round(num_in_filter * expansion_factor))
+    y = small_unit(name+"-mnv3_unit1", x, kernel_size=1, num_filter=expansion, strides=1, padding="VALID", num_group=1, act=act)
+    y = small_unit(name+"-mnv3_unit2", y, kernel_size=kernel_size, num_filter=expansion, strides=strides, 
+        padding=([0, 0, kernel_size//2, kernel_size//2]), num_group=expansion, act=act)  # check the padding
+    out = small_unit(name+"-mnv3_unit3", y, kernel_size=1, num_filter=num_filter, strides=1, padding="VALID", num_group=1, act=None)
+    if sechannel != None:
+        out = SeModule(name+"-semodule", out, sechannel)
+    if shortcut:
+        _x = small_unit(name+"-mnv3_unit_shortcut", x, kernel_size=1, num_filter=num_filter, strides=1, padding="VALID", num_group=1, act=None)
+    return out
+
+def MobileNetV3_Large(x, data_format="NCHW", num_class=1000):
+    layer1 = small_unit("large-layer1", x, num_filter=16, kernel_size=3, strides=2, padding="SAME", num_group=1, data_format=data_format, act="_hswish")
+    
+    layerneck = mnv3_unit("large-neck1", layer1, 3, 16, 16, False, 1, "_relu", None)
+    layerneck = mnv3_unit("large-neck2", layerneck, 3, 64, 24, False, 2, "_relu", None)
+    layerneck = mnv3_unit("large-neck3", layerneck, 3, 72, 24, False, 1, "_relu", None)
+    layerneck = mnv3_unit("large-neck4", layerneck, 5, 72, 40, False, 2, "_relu", 40) 
+    layerneck = mnv3_unit("large-neck5", layerneck, 5, 120, 40, False, 1, "_relu", 40)
+    layerneck = mnv3_unit("large-neck6", layerneck, 5, 120, 40, False, 1, "_relu", 40)
+    layerneck = mnv3_unit("large-neck7", layerneck, 3, 240, 80, False, 2, "_hswish", None)
+    layerneck = mnv3_unit("large-neck8", layerneck, 3, 200, 80, False, 1, "_hswish", None)
+    layerneck = mnv3_unit("large-neck9", layerneck, 3, 184, 80, False, 1, "_hswish", None)
+    layerneck = mnv3_unit("large-neck10", layerneck, 3, 184, 80, False, 1, "_hswish", None)
+    layerneck = mnv3_unit("large-neck11", layerneck, 3, 480, 112, True, 1, "_hswish", 112)
+    layerneck = mnv3_unit("large-neck12", layerneck, 3, 672, 112, False, 1, "_hswish", 112)
+    layerneck = mnv3_unit("large-neck13", layerneck, 5, 672, 160, True, 1, "_hswish", 160)
+    layerneck = mnv3_unit("large-neck14", layerneck, 5, 672, 160, False, 2, "_hswish", 160)
+    layerneck = mnv3_unit("large-neck15", layerneck, 3, 960, 160, False, 1, "_hswish", 160)
+    layer2 = small_unit("large-layer2", layerneck, num_filter=960, act="_hswish", padding="VALID")  # number > 1 exists
+
+    layer_avg = flow.nn.avg_pool2d(layer2, ksize=[layer2.shape[2], layer2.shape[3]], strides=None, padding="VALID")  # review it 
+    layer_view = flow.reshape(layer_avg, (layer_avg.shape[0], -1)) 
+    dense3 = flow.layers.dense(
+        layer_view, 
+        units=1280, 
+        use_bias=False,
+        kernel_initializer=_get_initializer("dense_weight"),
+        bias_initializer=_get_initializer("bias"),
+        kernel_regularizer=_get_regularizer("dense_weight"),
+        bias_regularizer=_get_regularizer("bias"),
+        name="dense3-large",
+        )
+    bn3 = _batch_norms("bn3-large", dense3, axis=1, momentum=0.9, epsilon=1e-5)
+    hs3 = hswish(bn3)
+    dense4 = flow.layers.dense(
+        hs3, 
+        units=num_class, 
+        use_bias=False,
+        kernel_initializer=_get_initializer("dense_weight"),
+        bias_initializer=_get_initializer("bias"),
+        kernel_regularizer=_get_regularizer("dense_weight"),
+        bias_regularizer=_get_regularizer("bias"),
+        name="dense4-large",
+    )
+
+    return dense4
+
+def MobileNetV3_Small(x, data_format="NCHW", num_class=1000):
+    layer1 = small_unit("small-layer1", x, num_filter=16, kernel_size=3, strides=2, padding="SAME", num_group=1, data_format=data_format, act="_hswish")
+
+    layerneck = mnv3_unit("small-neck1", layer1, 3, 16, 16, True, 1, "_relu", 16)
+    layerneck = mnv3_unit("small-neck2", layerneck, 3, 72, 24, False, 2, "_relu", None)
+    layerneck = mnv3_unit("small-neck3", layerneck, 3, 88, 24, False, 1, "_relu", None)
+    layerneck = mnv3_unit("small-neck4", layerneck, 5, 96, 40, False, 2, "_hswish", 40)
+    layerneck = mnv3_unit("small-neck5", layerneck, 5, 240, 40, True, 1, "_hswish", 40)
+    layerneck = mnv3_unit("small-neck6", layerneck, 5, 240, 40, True, 1, "_hswish", 40)
+    layerneck = mnv3_unit("small-neck7", layerneck, 5, 120, 48, False, 1, "_hswish", 48)
+    layerneck = mnv3_unit("small-neck8", layerneck, 5, 144, 48, True, 1, "_hswish", 48)
+    layerneck = mnv3_unit("small-neck9", layerneck, 5, 288, 96, False, 2, "_hswish", 96)
+    layerneck = mnv3_unit("small-neck10", layerneck, 5, 576, 96, True, 1, "_hswish", 96)
+    layerneck = mnv3_unit("small-neck11", layerneck, 5, 576, 96, True, 1, "_hswish", 96)
+
+    layer2 = small_unit("small-layer2", layerneck, num_filter=576, act="_hswish", padding="VALID")
+    layer_avg = flow.nn.avg_pool2d(layer2, ksize=[layer2.shape[2], layer2.shape[3]], strides=None, padding="VALID")  # review it
+    layer_view = flow.reshape(layer_avg, (layer_avg.shape[0], -1))
+    dense3 = flow.layers.dense(
+        layer_view, 
+        units=1280, 
+        use_bias=False,
+        kernel_initializer=_get_initializer("dense_weight"),
+        bias_initializer=_get_initializer("bias"),
+        kernel_regularizer=_get_regularizer("dense_weight"),
+        bias_regularizer=_get_regularizer("bias"),
+        name="dense3-large",
+        )
+    bn3 = _batch_norms("bn3-large", dense3, axis=1, momentum=0.9, epsilon=1e-5)
+    hs3 = hswish(bn3)
+    dense4 = flow.layers.dense(
+        hs3, 
+        units=num_class, 
+        use_bias=False,
+        kernel_initializer=_get_initializer("dense_weight"),
+        bias_initializer=_get_initializer("bias"),
+        kernel_regularizer=_get_regularizer("dense_weight"),
+        bias_regularizer=_get_regularizer("bias"),
+        name="dense4-large",
+        )
+    print(dense4.shape)
+
+    return dense4
+
+def Mobilenet_Large(input_data, args, trainable=True, training=True, num_classes=1000, prefix = ""):
+    assert   args.channel_last==False, "Mobilenet does not support channel_last mode, set channel_last=False will be right!"
+    data_format="NHWC" if args.channel_last else "NCHW"
+    out = MobileNetV3_Large(input_data, data_format=data_format, num_class=num_classes)
+    return out
+
+def Mobilenet_Small(input_data, args, trainable=True, training=True, num_classes=1000, prefix = ""):
+    assert   args.channel_last==False, "Mobilenet does not support channel_last mode, set channel_last=False will be right!"
+    data_format="NHWC" if args.channel_last else "NCHW"
+    out = MobileNetV3_Small(input_data, data_format=data_format, num_class=num_classes)
+    return out

--- a/MobileNetV3/mobilenet_v3_model.py
+++ b/MobileNetV3/mobilenet_v3_model.py
@@ -2,10 +2,6 @@ import oneflow as flow
 import oneflow.typing as tp
 import numpy as np
 
-"""
-感觉_get_initializer这一部分需要再考虑一下
-"""
-
 def _get_regularizer(model_name):
     #all decay
     return flow.regularizers.l2(0.00004)
@@ -216,13 +212,3 @@ def Mobilenet_Small(input_data, args, trainable=True, training=True, num_classes
     data_format="NHWC" if args.channel_last else "NCHW"
     out = MobileNetV3_Small(input_data, data_format=data_format, num_class=num_classes)
     return out
-
-"""
-@flow.global_function()
-def test_MNV3(x: tp.Numpy.Placeholder(shape=(2, 3, 320, 224)))->tp.Numpy:
-    return MobileNetV3_Large(x)
-
-x = np.random.randn(2, 3, 320, 224).astype(np.float32)
-print(test_MNV3(x))
-"""
-

--- a/MobileNetV3/mobilenet_v3_model.py
+++ b/MobileNetV3/mobilenet_v3_model.py
@@ -1,0 +1,228 @@
+import oneflow as flow
+import oneflow.typing as tp
+import numpy as np
+
+"""
+感觉_get_initializer这一部分需要再考虑一下
+"""
+
+def _get_regularizer(model_name):
+    #all decay
+    return flow.regularizers.l2(0.00004)
+
+def _get_initializer(model_name):
+    if model_name == "weight":
+        return flow.variance_scaling_initializer(2.0, mode="fan_in", distribution="random_normal", data_format="NCHW")
+    elif model_name == "bias":
+        return flow.zeros_initializer()
+    elif model_name == "gamma":
+        return flow.ones_initializer()
+    elif model_name == "beta":
+        return flow.zeros_initializer()
+    elif model_name == "dense_weight":
+        return flow.random_normal_initializer(0, 0.01)
+
+def _conv2d(name, x, filters, kernel_size, strides, num_group, padding="SAME", data_format="NCHW"):  # tested
+    assert data_format=="NCHW", "Mobilenet does not support channel_last mode."
+    weight_initializer = _get_initializer("weight")
+    weight_regularizer=_get_regularizer("beta")  # review it
+
+    shape = (filters, x.shape[1] // num_group, kernel_size, kernel_size)
+    weight = flow.get_variable(
+        name + "-weight",
+        shape=shape,
+        dtype=x.dtype,
+        initializer=weight_initializer,
+        regularizer=weight_regularizer,
+        model_name="--weight",
+        trainable=True,  # review it
+    )
+    return flow.nn.conv2d(x, weight, strides, padding, data_format, name=name, groups=num_group)
+
+def _batch_norms(name, x, axis, momentum, epsilon, center=True, scale=True, trainable=True):  # tested
+    return flow.layers.batch_normalization(
+        name=name,
+        inputs=x,
+        axis=axis,
+        momentum=momentum,
+        epsilon=epsilon,
+        center=center,
+        scale=scale,
+        beta_initializer = _get_initializer("beta"),
+        gamma_initializer = _get_initializer("gamma"),
+        beta_regularizer = _get_regularizer("beta"),
+        gamma_regularizer = _get_regularizer("gamma"),
+        trainable=trainable
+    )
+
+def hswish(x):
+    out =  x * flow.nn.relu6(x + 3) / 6
+    return out
+
+def hsigmoid(x):
+    out = flow.nn.relu6(x + 3) / 6
+    return out
+
+# valid numbers outputted
+def SeModule(name, x, channel, reduction=4):
+    N, C, H, W = x.shape
+
+    y = flow.nn.avg_pool2d(x, ksize=[H, W], strides=None, padding="SAME")  # check here
+    y = flow.flatten(y, start_dim=1, end_dim=-1)
+    y = flow.layers.dense(
+        y, 
+        units=channel // reduction, 
+        use_bias=False,
+        kernel_initializer=_get_initializer("dense_weight"),
+        bias_initializer=_get_initializer("bias"),
+        kernel_regularizer=_get_regularizer("dense_weight"),
+        bias_regularizer=_get_regularizer("bias"),
+        name=name+"dense1a",
+        )
+    y = flow.math.relu(y)
+    y = flow.layers.dense(
+        y, 
+        units=channel, 
+        use_bias=False,
+        kernel_initializer=_get_initializer("dense_weight"),
+        bias_initializer=_get_initializer("bias"),
+        kernel_regularizer=_get_regularizer("dense_weight"),
+        bias_regularizer=_get_regularizer("bias"),
+        name=name+"dense2",
+        )
+    y = hsigmoid(y)
+    y = flow.expand_dims(input=y, axis=2)
+    y = flow.expand_dims(input=y, axis=3)
+    y_expand = flow.broadcast_like(y, x, broadcast_axes=(2, 3))
+    out = x * y_expand
+    return out
+
+# valid number outputted
+def small_unit(name, x, kernel_size=1, num_filter=1, strides=1, padding="SAME", num_group=1, data_format="NCHW", act=None):
+    conv = _conv2d(name=name+"-small_unit", x=x, filters=num_filter, kernel_size=kernel_size, strides=strides,
+            num_group=num_group, padding=padding, data_format=data_format)
+    bn = _batch_norms(name+"-small_unit_bn", conv, axis=1, momentum=0.9, epsilon=1e-5)
+    if act == "_relu":
+        return flow.math.relu(bn)
+    elif act == "_hswish":
+        return hswish(bn)
+    else:
+        return bn
+
+# valid numbers outputted. But may be strange.
+def mnv3_unit(name, x, kernel_size, expansion, num_filter, shortcut, strides, act, sechannel, data_format="NCHW"):
+    # num_exp_filter = int(round(num_in_filter * expansion_factor))
+    y = small_unit(name+"-mnv3_unit1", x, kernel_size=1, num_filter=expansion, strides=1, padding="VALID", num_group=1, act=act)
+    y = small_unit(name+"-mnv3_unit2", y, kernel_size=kernel_size, num_filter=expansion, strides=strides, 
+        padding=([0, 0, kernel_size//2, kernel_size//2]), num_group=expansion, act=act)  # check the padding
+    out = small_unit(name+"-mnv3_unit3", y, kernel_size=1, num_filter=num_filter, strides=1, padding="VALID", num_group=1, act=None)
+    if sechannel != None:
+        out = SeModule(name+"-semodule", out, sechannel)
+    if shortcut:
+        _x = small_unit(name+"-mnv3_unit_shortcut", x, kernel_size=1, num_filter=num_filter, strides=1, padding="VALID", num_group=1, act=None)
+    return out
+
+def MobileNetV3_Large(x, data_format="NCHW", num_class=1000):
+    layer1 = small_unit("large-layer1", x, num_filter=16, kernel_size=3, strides=2, padding="SAME", num_group=1, data_format=data_format, act="_hswish")
+    
+    layerneck = mnv3_unit("large-neck1", layer1, 3, 16, 16, False, 1, "_relu", None)
+    layerneck = mnv3_unit("large-neck2", layerneck, 3, 64, 24, False, 2, "_relu", None)
+    layerneck = mnv3_unit("large-neck3", layerneck, 3, 72, 24, False, 1, "_relu", None)
+    layerneck = mnv3_unit("large-neck4", layerneck, 5, 72, 40, False, 2, "_relu", 40) 
+    layerneck = mnv3_unit("large-neck5", layerneck, 5, 120, 40, False, 1, "_relu", 40)
+    layerneck = mnv3_unit("large-neck6", layerneck, 5, 120, 40, False, 1, "_relu", 40)
+    layerneck = mnv3_unit("large-neck7", layerneck, 3, 240, 80, False, 2, "_hswish", None)
+    layerneck = mnv3_unit("large-neck8", layerneck, 3, 200, 80, False, 1, "_hswish", None)
+    layerneck = mnv3_unit("large-neck9", layerneck, 3, 184, 80, False, 1, "_hswish", None)
+    layerneck = mnv3_unit("large-neck10", layerneck, 3, 184, 80, False, 1, "_hswish", None)
+    layerneck = mnv3_unit("large-neck11", layerneck, 3, 480, 112, True, 1, "_hswish", 112)
+    layerneck = mnv3_unit("large-neck12", layerneck, 3, 672, 112, False, 1, "_hswish", 112)
+    layerneck = mnv3_unit("large-neck13", layerneck, 5, 672, 160, True, 1, "_hswish", 160)
+    layerneck = mnv3_unit("large-neck14", layerneck, 5, 672, 160, False, 2, "_hswish", 160)
+    layerneck = mnv3_unit("large-neck15", layerneck, 3, 960, 160, False, 1, "_hswish", 160)
+    layer2 = small_unit("large-layer2", layerneck, num_filter=960, act="_hswish", padding="VALID")  # number > 1 exists
+
+    layer_avg = flow.nn.avg_pool2d(layer2, ksize=[layer2.shape[2], layer2.shape[3]], strides=None, padding="VALID")  # review it 
+    layer_view = flow.reshape(layer_avg, (layer_avg.shape[0], -1))  # review it
+
+    dense3 = flow.layers.dense(
+        layer_view, 
+        units=1280, 
+        use_bias=False,
+        kernel_initializer=_get_initializer("dense_weight"),
+        bias_initializer=_get_initializer("bias"),
+        kernel_regularizer=_get_regularizer("dense_weight"),
+        bias_regularizer=_get_regularizer("bias"),
+        name="dense3-large",
+        )
+    bn3 = _batch_norms("bn3-large", dense3, axis=1, momentum=0.9, epsilon=1e-5)
+    hs3 = hswish(bn3)
+    dense4 = flow.layers.dense(
+        hs3, 
+        units=num_class, 
+        use_bias=False,
+        kernel_initializer=_get_initializer("dense_weight"),
+        bias_initializer=_get_initializer("bias"),
+        kernel_regularizer=_get_regularizer("dense_weight"),
+        bias_regularizer=_get_regularizer("bias"),
+        name="dense4-large",
+    )
+
+    return dense4
+
+def MobileNetV3_Small(x, data_format="NCHW", num_class=1000):
+    layer1 = small_unit("small-layer1", x, num_filter=16, kernel_size=3, strides=2, padding="SAME", num_group=1, data_format=data_format, act="_hswish")
+
+    layerneck = mnv3_unit("small-neck1", layer1, 3, 16, 16, True, 1, "_relu", 16)
+    layerneck = mnv3_unit("small-neck2", layerneck, 3, 72, 24, False, 2, "_relu", None)
+    layerneck = mnv3_unit("small-neck3", layerneck, 3, 88, 24, False, 1, "_relu", None)
+    layerneck = mnv3_unit("small-neck4", layerneck, 5, 96, 40, False, 2, "_hswish", 40)
+    layerneck = mnv3_unit("small-neck5", layerneck, 5, 240, 40, True, 1, "_hswish", 40)
+    layerneck = mnv3_unit("small-neck6", layerneck, 5, 240, 40, True, 1, "_hswish", 40)
+    layerneck = mnv3_unit("small-neck7", layerneck, 5, 120, 48, False, 1, "_hswish", 48)
+    layerneck = mnv3_unit("small-neck8", layerneck, 5, 144, 48, True, 1, "_hswish", 48)
+    layerneck = mnv3_unit("small-neck9", layerneck, 5, 288, 96, False, 2, "_hswish", 96)
+    layerneck = mnv3_unit("small-neck10", layerneck, 5, 576, 96, True, 1, "_hswish", 96)
+    layerneck = mnv3_unit("small-neck11", layerneck, 5, 576, 96, True, 1, "_hswish", 96)
+
+    layer2 = small_unit("small-layer2", layerneck, num_filter=576, act="_hswish")
+    layer_avg = flow.nn.avg_pool2d(layer2, ksize=[layer2.shape[2], layer2.shape[3]], strides=None, padding="VALID")  # review it
+    layer_view = flow.reshape(layer_avg, (layer_avg.shape[0], -1))  # review it
+    dense3 = flow.layers.dense(layer_view, 1280)
+    bn3 = _batch_norms("bn3-large", dense3, axis=1, momentum=0.9, epsilon=1e-5)
+    hs3 = hswish(bn3)
+    dense4 = flow.layers.dense(
+        hs3, 
+        units=num_class, 
+        use_bias=False,
+        kernel_initializer=_get_initializer("dense_weight"),
+        bias_initializer=_get_initializer("bias"),
+        kernel_regularizer=_get_regularizer("dense_weight"),
+        bias_regularizer=_get_regularizer("bias"),
+        name="dense4-large",
+        )
+    print(dense4.shape)
+
+    return dense4
+
+def Mobilenet_Large(input_data, args, trainable=True, training=True, num_classes=1000, prefix = ""):
+    assert   args.channel_last==False, "Mobilenet does not support channel_last mode, set channel_last=False will be right!"
+    data_format="NHWC" if args.channel_last else "NCHW"
+    out = MobileNetV3_Large(input_data, data_format=data_format, num_class=num_classes)
+    return out
+
+def Mobilenet_Small(input_data, args, trainable=True, training=True, num_classes=1000, prefix = ""):
+    assert   args.channel_last==False, "Mobilenet does not support channel_last mode, set channel_last=False will be right!"
+    data_format="NHWC" if args.channel_last else "NCHW"
+    out = MobileNetV3_Small(input_data, data_format=data_format, num_class=num_classes)
+    return out
+
+"""
+@flow.global_function()
+def test_MNV3(x: tp.Numpy.Placeholder(shape=(2, 3, 320, 224)))->tp.Numpy:
+    return MobileNetV3_Large(x)
+
+x = np.random.randn(2, 3, 320, 224).astype(np.float32)
+print(test_MNV3(x))
+"""
+

--- a/MobileNetV3/mobilenet_v3_model.py
+++ b/MobileNetV3/mobilenet_v3_model.py
@@ -167,18 +167,18 @@ def MobileNetV3_Small(x, data_format="NCHW", num_class=1000):
     layerneck = mnv3_unit("small-neck1", layer1, 3, 16, 16, True, 1, "_relu", 16)
     layerneck = mnv3_unit("small-neck2", layerneck, 3, 72, 24, False, 2, "_relu", None)
     layerneck = mnv3_unit("small-neck3", layerneck, 3, 88, 24, False, 1, "_relu", None)
-    layerneck = mnv3_unit("small-neck4", layerneck, 5, 96, 40, False, 2, "_hswish", 40)
+    layerneck = mnv3_unit("small-neck4", layerneck, 5, 96, 40, True, 2, "_hswish", 40)
     layerneck = mnv3_unit("small-neck5", layerneck, 5, 240, 40, True, 1, "_hswish", 40)
     layerneck = mnv3_unit("small-neck6", layerneck, 5, 240, 40, True, 1, "_hswish", 40)
-    layerneck = mnv3_unit("small-neck7", layerneck, 5, 120, 48, False, 1, "_hswish", 48)
+    layerneck = mnv3_unit("small-neck7", layerneck, 5, 120, 48, True, 1, "_hswish", 48)
     layerneck = mnv3_unit("small-neck8", layerneck, 5, 144, 48, True, 1, "_hswish", 48)
-    layerneck = mnv3_unit("small-neck9", layerneck, 5, 288, 96, False, 2, "_hswish", 96)
+    layerneck = mnv3_unit("small-neck9", layerneck, 5, 288, 96, True, 2, "_hswish", 96)
     layerneck = mnv3_unit("small-neck10", layerneck, 5, 576, 96, True, 1, "_hswish", 96)
     layerneck = mnv3_unit("small-neck11", layerneck, 5, 576, 96, True, 1, "_hswish", 96)
 
     layer2 = small_unit("small-layer2", layerneck, num_filter=576, act="_hswish", padding="VALID")
-    layer_avg = flow.nn.avg_pool2d(layer2, ksize=[layer2.shape[2], layer2.shape[3]], strides=None, padding="VALID")
-    layer_view = flow.reshape(layer_avg, (layer_avg.shape[0], -1))
+    layer_avg = flow.nn.avg_pool2d(layer2, ksize=[layer2.shape[2], layer2.shape[3]], strides=None, padding="VALID")  # review it
+    layer_view = flow.reshape(layer_avg, (layer_avg.shape[0], -1))  # review it
     dense3 = flow.layers.dense(
         layer_view, 
         units=1280, 


### PR DESCRIPTION
MobileNetV3 model, including MobileNetV3-Large and MobileNetV3-Small model are added to the OneFlow Vision Model.

Both MobileNetV3-Large and MobileNetV3-Small models are tested on ImageNet dataset, yet both models have lower accuracy than the paper. Model improvements are necessary to be conducted in the future, and codes will be renewed after that.